### PR TITLE
closes #38 | remove authorization from the topics route

### DIFF
--- a/src/server/routes/topics.js
+++ b/src/server/routes/topics.js
@@ -9,11 +9,11 @@ const authorization = require('./../middleware/authorization');
 const topicRoutes = function (router) {
   router.route('/topics')
     .get(topics.getAll)
-    .post(authentication, authorization, topics.create);
+    .post(authentication, topics.create);
 
   router.route('/topics/:id')
     .get(topics.getOne)
-    .put(authentication, authorization, topics.update)
+    .put(authentication, topics.update)
     .delete(authentication, authorization, topics.delete);
 
   router.route('/topics/:id/full')

--- a/tests/server/users.spec.js
+++ b/tests/server/users.spec.js
@@ -45,7 +45,6 @@ describe('Users', function () {
       .set('x-access-token', adminToken)
       .expect(200)
       .end(function (err, res) {
-        console.log(res);
         res.status.should.equal(200);
         res.body.should.be.type('object');
         done();


### PR DESCRIPTION
chore: removes authorization checks from the topics creation and updating routes